### PR TITLE
Fix Go Standard Library link

### DIFF
--- a/2014/03/22/rust-vs-go/index.html
+++ b/2014/03/22/rust-vs-go/index.html
@@ -72,7 +72,7 @@
 
 <h3 id="standardlibrary">Standard Library</h3>
 
-<p>Go has a <a href="http://static.rust-lang.org/doc/master/std/index.html">really solid standard library</a>, making everything from image en/decoding to building a web server to cryptography simple and straightforward.</p>
+<p>Go has a <a href="http://golang.org/pkg/">really solid standard library</a>, making everything from image en/decoding to building a web server to cryptography simple and straightforward.</p>
 
 <p>Rust's <a href="http://static.rust-lang.org/doc/master/std/index.html">standard library</a> leaves a lot to be desired. Again, this can be blamed on the general immaturity of the language (it would be a pain to rewrite a huge std library every time the syntax changes).</p>
 


### PR DESCRIPTION
IT used to link to the rust library, but now links to golang.org/pkg
